### PR TITLE
> ※ 2024.06.03 pdg : 데이터 체크 

### DIFF
--- a/DataAnalysis/02.스마트서울 도시데이터 센서(S-DoT) 유동인구 측정 정보.ipynb
+++ b/DataAnalysis/02.스마트서울 도시데이터 센서(S-DoT) 유동인구 측정 정보.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "---\n",
+    "## Projectr : 스마트서울 도시데이터 센서(S-DoT) 유동인구 측정 정보분석 ver.01\n",
+    "### Description : \n",
+    "    - 스마트서울 도시데이터 센서(S-DoT) 유동인구 측정 정보\n",
+    "    [source link](https://data.seoul.go.kr/dataList/OA-15964/S/1/datasetView.do)\n",
+    "    - 센서수량 및 설치장소 : 서울 전역 100대(전통시장, 주요거리, 공원, 공공시설)\n",
+    "    - 측정정보 : S-DoT에서 측정된 유동인구(10분단위 데이터)\n",
+    "    - 유동인구 센서는 WiFi AP셀 반경내 휴대폰의 MAC주소를 카운팅(50대)하거나 CCTV를 활용한 피플카운팅(50대) 방식으로 정확한 유동인구를 측정한 것이 아닙니다.\n",
+    "    - 데이터의 양이 많아 2023년 10월 16일부터 Sheet와 OpenAPI는 최근 한달만 출력됩니다.\n",
+    "### Author : Forrest Dpark (분석 담당)\n",
+    "### Date : 2024.05.31 ~\n",
+    "### Detail :  \n",
+    "### Update: \n",
+    "    > ※ 2024.06.03 pdg : 데이터 체크 \n",
+    "        - api 연결\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION


## Projectr : 스마트서울 도시데이터 센서(S-DoT) 유동인구 측정 정보분석 ver.01
### Description : 
    - 스마트서울 도시데이터 센서(S-DoT) 유동인구 측정 정보
    [source link](https://data.seoul.go.kr/dataList/OA-15964/S/1/datasetView.do)
    - 센서수량 및 설치장소 : 서울 전역 100대(전통시장, 주요거리, 공원, 공공시설)
    - 측정정보 : S-DoT에서 측정된 유동인구(10분단위 데이터)
    - 유동인구 센서는 WiFi AP셀 반경내 휴대폰의 MAC주소를 카운팅(50대)하거나 CCTV를 활용한 피플카운팅(50대) 방식으로 정확한 유동인구를 측정한 것이 아닙니다.
    - 데이터의 양이 많아 2023년 10월 16일부터 Sheet와 OpenAPI는 최근 한달만 출력됩니다.
### Author : Forrest Dpark (분석 담당)
### Date : 2024.05.31 ~
### Detail :  
### Update: 
    > ※ 2024.06.03 pdg : 데이터 체크 
        - api 연결
---